### PR TITLE
Add analytical layer

### DIFF
--- a/infrastructure/orchestration/dags/dag.py
+++ b/infrastructure/orchestration/dags/dag.py
@@ -28,7 +28,7 @@ DEFAULT_ARGS = {
 def hn_etl():
     """
     Pipeline ETL:
-    ingestion -> processing -> transformation
+    ingestion -> processing -> transformation -> analytics
     """
 
     # Argumentos comunes para todos los contenedores efímeros
@@ -65,7 +65,13 @@ def hn_etl():
         **common_docker_args,
     )
 
-    ingestion >> processing >> transformation
+    analytics = DockerOperator(
+        task_id="analytics",
+        command="python -m analytics.main {{ data_interval_end.strftime('%Y-%m-%d') }}",
+        **common_docker_args,
+    )
+
+    ingestion >> processing >> transformation >> analytics
 
 
 # Instancia del DAG

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -51,3 +51,8 @@ resource "aws_s3_object" "metadata" {
   bucket = aws_s3_bucket.datalake.id
   key    = "metadata/"
 }
+
+resource "aws_s3_object" "reports" {
+  bucket = aws_s3_bucket.datalake.id
+  key    = "reports/"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.13"
 dependencies = [
     "boto3>=1.42.40",
     "cryptography>=46.0.4",
+    "duckdb>=1.3.0",
     "pandas>=3.0.0",
     "pyarrow>=23.0.0",
     "python-dotenv>=1.2.1",
@@ -18,7 +19,7 @@ dependencies = [
     "scikit-learn>=1.6.0",
     "vaderSentiment>=3.3.2",
 ]
-license = {text = "MIT"}
+license = "MIT"
 authors = [
     {name = "Gerardo Toboso", email = "gerardotoboso1909@gmail.com"}
 ]

--- a/src/analytics/hn_analytics.py
+++ b/src/analytics/hn_analytics.py
@@ -1,0 +1,209 @@
+"""
+Módulo encargado de ejecutar consultas analíticas de negocio sobre output/.
+Usa DuckDB para queries SQL sobre Parquet almacenados en S3 (MinIO).
+"""
+
+from typing import Optional
+
+import duckdb
+import pandas as pd
+
+from utils.logger import analytics_logger as logger
+
+
+class HNAnalytics:
+    """
+    Motor de consultas analíticas sobre el data lake.
+
+    Conecta a S3 (MinIO) via DuckDB httpfs y ejecuta queries de negocio
+    sobre los datos enriquecidos en output/. Cada método público representa
+    una consulta de negocio y retorna un DataFrame con los resultados.
+    """
+
+    def __init__(
+        self, bucket_name: str, endpoint_url: str, access_key: str, secret_key: str
+    ):
+        """
+        Args:
+            bucket_name: Nombre del bucket S3
+            endpoint_url: Endpoint de S3/MinIO (ej: http://minio:9000)
+            access_key: Access key de S3
+            secret_key: Secret key de S3
+        """
+        self.bucket = bucket_name
+        self.conn = duckdb.connect()
+
+        self.conn.execute("INSTALL httpfs; LOAD httpfs;")
+        self.conn.execute(f"SET s3_endpoint='{endpoint_url.replace('http://', '')}';")
+        self.conn.execute(f"SET s3_access_key_id='{access_key}';")
+        self.conn.execute(f"SET s3_secret_access_key='{secret_key}';")
+        self.conn.execute("SET s3_use_ssl=false;")
+        self.conn.execute("SET s3_url_style='path';")
+
+        logger.info(f"Conexión DuckDB a S3 establecida (bucket: {bucket_name})")
+
+    def _output_path(self, entity: str, date: Optional[str] = None) -> str:
+        """
+        Construye la ruta S3 hacia los Parquet de output/.
+
+        Args:
+            entity: Entidad (stories, comments)
+            date: Fecha de partición (YYYY-MM-DD). Si None, lee todas.
+
+        Returns:
+            Ruta glob S3 para read_parquet
+        """
+        base = f"s3://{self.bucket}/output/{entity}"
+        if date:
+            return f"{base}/ingestion_date={date}/*.parquet"
+        return f"{base}/**/*.parquet"
+
+    def top_stories_by_score_velocity(self, date: str, limit: int = 20) -> pd.DataFrame:
+        """
+        Top stories ordenadas por velocidad de crecimiento de score.
+
+        Args:
+            date: Fecha de ingesta (YYYY-MM-DD)
+            limit: Cantidad máxima de resultados
+
+        Returns:
+            DataFrame con las stories de mayor score velocity
+        """
+        path = self._output_path("stories", date)
+        logger.info(
+            f"Ejecutando top_stories_by_score_velocity (date={date}, limit={limit})"
+        )
+
+        return self.conn.execute(f"""
+            SELECT id, title, score, score_velocity, comment_velocity,
+                   hours_to_peak, is_long_tail, dominant_topics
+            FROM read_parquet('{path}')
+            ORDER BY score_velocity DESC
+            LIMIT {limit}
+        """).df()
+
+    def engagement_speed(self, date: str) -> pd.DataFrame:
+        """
+        Clasifica stories por velocidad de engagement según hours_to_peak.
+
+        Categorías: fast (<=6h), medium (6-24h), slow (>24h).
+
+        Args:
+            date: Fecha de ingesta (YYYY-MM-DD)
+
+        Returns:
+            DataFrame con conteo, score y comments promedio por categoría
+        """
+        path = self._output_path("stories", date)
+        logger.info(f"Ejecutando engagement_speed (date={date})")
+
+        return self.conn.execute(f"""
+            SELECT
+                CASE
+                    WHEN hours_to_peak <= 6 THEN 'fast (<=6h)'
+                    WHEN hours_to_peak <= 24 THEN 'medium (6-24h)'
+                    ELSE 'slow (>24h)'
+                END AS speed_category,
+                COUNT(*) AS story_count,
+                ROUND(AVG(score), 1) AS avg_score,
+                ROUND(AVG(descendants), 1) AS avg_comments
+            FROM read_parquet('{path}')
+            GROUP BY speed_category
+            ORDER BY story_count DESC
+        """).df()
+
+    def long_tail_stories(self, date: str) -> pd.DataFrame:
+        """
+        Stories con actividad sostenida (>48h de engagement).
+
+        Args:
+            date: Fecha de ingesta (YYYY-MM-DD)
+
+        Returns:
+            DataFrame con stories long tail ordenadas por comment velocity
+        """
+        path = self._output_path("stories", date)
+        logger.info(f"Ejecutando long_tail_stories (date={date})")
+
+        return self.conn.execute(f"""
+            SELECT id, title, score, descendants, hours_to_peak,
+                   comment_velocity, observations_in_window
+            FROM read_parquet('{path}')
+            WHERE is_long_tail = true
+            ORDER BY comment_velocity DESC
+        """).df()
+
+    def sentiment_by_story(self, stories_date: str, comments_date: str) -> pd.DataFrame:
+        """
+        Análisis de sentimiento agregado por story.
+
+        Cruza stories con comments para obtener distribución de sentimiento
+        (positivo, negativo, neutro) por cada story.
+
+        Args:
+            stories_date: Fecha de partición de stories (YYYY-MM-DD)
+            comments_date: Fecha de partición de comments (YYYY-MM-DD)
+
+        Returns:
+            DataFrame con métricas de sentimiento por story
+        """
+        stories_path = self._output_path("stories", stories_date)
+        comments_path = self._output_path("comments", comments_date)
+        logger.info(
+            f"Ejecutando sentiment_by_story "
+            f"(stories={stories_date}, comments={comments_date})"
+        )
+
+        return self.conn.execute(f"""
+            SELECT s.id, s.title,
+                   COUNT(c.id) AS total_comments,
+                   ROUND(AVG(c.sentiment_score), 4) AS avg_sentiment,
+                   SUM(CASE WHEN c.sentiment_label = 'positive' THEN 1 ELSE 0 END) AS positive,
+                   SUM(CASE WHEN c.sentiment_label = 'negative' THEN 1 ELSE 0 END) AS negative,
+                   SUM(CASE WHEN c.sentiment_label = 'neutral' THEN 1 ELSE 0 END) AS neutral
+            FROM read_parquet('{stories_path}') s
+            JOIN read_parquet('{comments_path}') c ON s.id = c.parent
+            GROUP BY s.id, s.title
+            ORDER BY total_comments DESC
+        """).df()
+
+    def topic_trends(self, date: str) -> pd.DataFrame:
+        """
+        Frecuencia y score promedio de los topics dominantes.
+
+        Separa el campo dominant_topics (CSV) en filas individuales
+        y calcula frecuencia y score promedio por topic.
+
+        Args:
+            date: Fecha de ingesta (YYYY-MM-DD)
+
+        Returns:
+            DataFrame con topic, frecuencia y score promedio
+        """
+        path = self._output_path("stories", date)
+        logger.info(f"Ejecutando topic_trends (date={date})")
+
+        return self.conn.execute(f"""
+            WITH topics_split AS (
+                SELECT
+                    string_split(dominant_topics, ',') AS topic_list,
+                    score
+                FROM read_parquet('{path}')
+                WHERE dominant_topics IS NOT NULL
+            ),
+            topics_flat AS (
+                SELECT
+                    UNNEST(topic_list) AS topic,
+                    score
+                FROM topics_split
+            )
+            SELECT
+                TRIM(topic) AS topic,
+                COUNT(*) AS frequency,
+                ROUND(AVG(score), 1) AS avg_score
+            FROM topics_flat
+            WHERE TRIM(topic) != ''
+            GROUP BY TRIM(topic)
+            ORDER BY frequency DESC
+            LIMIT 30
+        """).df()

--- a/src/analytics/main.py
+++ b/src/analytics/main.py
@@ -1,0 +1,131 @@
+"""
+Punto de entrada para la capa de reportes analíticos (output -> reports).
+Ejecuta queries de negocio sobre output/ usando DuckDB y persiste CSV en reports/.
+"""
+
+import os
+import sys
+from datetime import datetime
+
+import boto3
+
+from analytics.hn_analytics import HNAnalytics
+from utils.layer_storage_writer import LayerStorageWriter
+from utils.logger import analytics_logger as logger
+from utils.logger import get_log_file_path
+
+# Registro de queries: (nombre_reporte, método, kwargs adicionales)
+REPORT_QUERIES = [
+    ("top_stories_by_score_velocity", "top_stories_by_score_velocity", {}),
+    ("engagement_speed", "engagement_speed", {}),
+    ("long_tail_stories", "long_tail_stories", {}),
+    ("sentiment_by_story", "sentiment_by_story", {}),
+    ("topic_trends", "topic_trends", {}),
+]
+
+
+def _run_and_save(
+    analytics: HNAnalytics,
+    writer: LayerStorageWriter,
+    ingestion_date: str,
+) -> dict:
+    """
+    Ejecuta todas las queries analíticas y guarda los resultados como CSV en reports/.
+
+    Returns:
+        Estadísticas de ejecución.
+    """
+    stats = {"reports_generated": 0, "reports_empty": 0, "reports_failed": 0}
+
+    for report_name, method_name, extra_kwargs in REPORT_QUERIES:
+        try:
+            # sentiment_by_story requiere ambas fechas
+            if method_name == "sentiment_by_story":
+                df = getattr(analytics, method_name)(ingestion_date, ingestion_date)
+            else:
+                df = getattr(analytics, method_name)(ingestion_date, **extra_kwargs)
+
+            if df.empty:
+                logger.warning(f"Reporte '{report_name}' sin resultados, omitido")
+                stats["reports_empty"] += 1
+                continue
+
+            records = df.to_dict(orient="records")
+            key = writer.save(
+                layer="reports",
+                entity=report_name,
+                data=records,
+                format="csv",
+                partition_date=ingestion_date,
+            )
+            logger.info(f"Reporte '{report_name}': {len(records)} filas -> {key}")
+            stats["reports_generated"] += 1
+
+        except Exception as e:
+            logger.error(f"Error generando reporte '{report_name}': {e}", exc_info=True)
+            stats["reports_failed"] += 1
+
+    return stats
+
+
+def run(ingestion_date: str):
+    """
+    Punto de entrada principal: inicializa componentes y ejecuta reportes analíticos.
+
+    Args:
+        ingestion_date: Fecha de ingesta a analizar (YYYY-MM-DD).
+    """
+    ingestion_date = ingestion_date or datetime.utcnow().strftime("%Y-%m-%d")
+
+    logger.info(
+        f"=== Empezando generación de reportes para fecha de ingesta: {ingestion_date} ==="
+    )
+
+    s3_client = boto3.client(
+        "s3",
+        endpoint_url=os.getenv("AWS_ENDPOINT_URL"),
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+    )
+    bucket_name = os.getenv("AWS_BUCKET_NAME")
+
+    writer = LayerStorageWriter(bucket_name=bucket_name, s3_client=s3_client)
+    analytics = HNAnalytics(
+        bucket_name=bucket_name,
+        endpoint_url=os.getenv("AWS_ENDPOINT_URL"),
+        access_key=os.getenv("AWS_ACCESS_KEY_ID"),
+        secret_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+    )
+
+    try:
+        stats = _run_and_save(analytics, writer, ingestion_date)
+
+        logger.info(
+            f"Reportes completados: "
+            f"{stats['reports_generated']} generados, "
+            f"{stats['reports_empty']} vacíos, "
+            f"{stats['reports_failed']} fallidos"
+        )
+
+    except Exception as e:
+        logger.error(f"Error durante la generación de reportes: {e}", exc_info=True)
+        raise
+
+    finally:
+        try:
+            analytics_log = get_log_file_path("analytics.log")
+            storage_log = get_log_file_path("storage.log")
+            writer.upload_log_file(pipeline="analytics", log_file_path=analytics_log)
+            writer.upload_log_file(pipeline="storage", log_file_path=storage_log)
+        except Exception as e:
+            logger.error(f"No se pudo subir el log a S3: {e}")
+
+
+if __name__ == "__main__":
+    try:
+        date_arg = sys.argv[1] if len(sys.argv) > 1 else None
+        if not date_arg:
+            raise ValueError("Fecha de ingesta no proporcionada")
+        run(ingestion_date=date_arg)
+    except Exception:
+        sys.exit(1)

--- a/src/ingestion/hn_fetcher.py
+++ b/src/ingestion/hn_fetcher.py
@@ -2,7 +2,6 @@
 Lógica de negocio para fetch de historias y comentarios.
 """
 
-from asyncio import Runner
 from datetime import datetime, timedelta
 from typing import Any, Dict, Generator, List
 

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -74,3 +74,4 @@ quality_logger = get_logger(name="quality_logger", filename="quality.log")
 transformation_logger = get_logger(
     name="transformation_logger", filename="transformation.log"
 )
+analytics_logger = get_logger(name="analytics_logger", filename="analytics.log")

--- a/uv.lock
+++ b/uv.lock
@@ -257,12 +257,35 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/9d/ab66a06e416d71b7bdcb9904cdf8d4db3379ef632bb8e9495646702d9718/duckdb-1.4.4.tar.gz", hash = "sha256:8bba52fd2acb67668a4615ee17ee51814124223de836d9e2fdcbc4c9021b3d3c", size = 18419763, upload-time = "2026-01-26T11:50:37.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/fe/64810fee20030f2bf96ce28b527060564864ce5b934b50888eda2cbf99dd/duckdb-1.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:337f8b24e89bc2e12dadcfe87b4eb1c00fd920f68ab07bc9b70960d6523b8bc3", size = 28899349, upload-time = "2026-01-26T11:49:40.294Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/9b/3c7c5e48456b69365d952ac201666053de2700f5b0144a699a4dc6854507/duckdb-1.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0509b39ea7af8cff0198a99d206dca753c62844adab54e545984c2e2c1381616", size = 15350691, upload-time = "2026-01-26T11:49:43.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/7b/64e68a7b857ed0340045501535a0da99ea5d9d5ea3708fec0afb8663eb27/duckdb-1.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fb94de6d023de9d79b7edc1ae07ee1d0b4f5fa8a9dcec799650b5befdf7aafec", size = 13672311, upload-time = "2026-01-26T11:49:46.069Z" },
+    { url = "https://files.pythonhosted.org/packages/09/5b/3e7aa490841784d223de61beb2ae64e82331501bf5a415dc87a0e27b4663/duckdb-1.4.4-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d636ceda422e7babd5e2f7275f6a0d1a3405e6a01873f00d38b72118d30c10b", size = 18422740, upload-time = "2026-01-26T11:49:49.034Z" },
+    { url = "https://files.pythonhosted.org/packages/53/32/256df3dbaa198c58539ad94f9a41e98c2c8ff23f126b8f5f52c7dcd0a738/duckdb-1.4.4-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df7351328ffb812a4a289732f500d621e7de9942a3a2c9b6d4afcf4c0e72526", size = 20435578, upload-time = "2026-01-26T11:49:51.946Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f0/620323fd87062ea43e527a2d5ed9e55b525e0847c17d3b307094ddab98a2/duckdb-1.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:6fb1225a9ea5877421481d59a6c556a9532c32c16c7ae6ca8d127e2b878c9389", size = 12268083, upload-time = "2026-01-26T11:49:54.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/07/a397fdb7c95388ba9c055b9a3d38dfee92093f4427bc6946cf9543b1d216/duckdb-1.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:f28a18cc790217e5b347bb91b2cab27aafc557c58d3d8382e04b4fe55d0c3f66", size = 13006123, upload-time = "2026-01-26T11:49:57.092Z" },
+    { url = "https://files.pythonhosted.org/packages/97/a6/f19e2864e651b0bd8e4db2b0c455e7e0d71e0d4cd2cd9cc052f518e43eb3/duckdb-1.4.4-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:25874f8b1355e96178079e37312c3ba6d61a2354f51319dae860cf21335c3a20", size = 28909554, upload-time = "2026-01-26T11:50:00.107Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/93/8a24e932c67414fd2c45bed83218e62b73348996bf859eda020c224774b2/duckdb-1.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:452c5b5d6c349dc5d1154eb2062ee547296fcbd0c20e9df1ed00b5e1809089da", size = 15353804, upload-time = "2026-01-26T11:50:03.382Z" },
+    { url = "https://files.pythonhosted.org/packages/62/13/e5378ff5bb1d4397655d840b34b642b1b23cdd82ae19599e62dc4b9461c9/duckdb-1.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8e5c2d8a0452df55e092959c0bfc8ab8897ac3ea0f754cb3b0ab3e165cd79aff", size = 13676157, upload-time = "2026-01-26T11:50:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/94/24364da564b27aeebe44481f15bd0197a0b535ec93f188a6b1b98c22f082/duckdb-1.4.4-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1af6e76fe8bd24875dc56dd8e38300d64dc708cd2e772f67b9fbc635cc3066a3", size = 18426882, upload-time = "2026-01-26T11:50:08.97Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0a/6ae31b2914b4dc34243279b2301554bcbc5f1a09ccc82600486c49ab71d1/duckdb-1.4.4-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0440f59e0cd9936a9ebfcf7a13312eda480c79214ffed3878d75947fc3b7d6d", size = 20435641, upload-time = "2026-01-26T11:50:12.188Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b1/fd5c37c53d45efe979f67e9bd49aaceef640147bb18f0699a19edd1874d6/duckdb-1.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:59c8d76016dde854beab844935b1ec31de358d4053e792988108e995b18c08e7", size = 12762360, upload-time = "2026-01-26T11:50:14.76Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2d/13e6024e613679d8a489dd922f199ef4b1d08a456a58eadd96dc2f05171f/duckdb-1.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:53cd6423136ab44383ec9955aefe7599b3fb3dd1fe006161e6396d8167e0e0d4", size = 13458633, upload-time = "2026-01-26T11:50:17.657Z" },
+]
+
+[[package]]
 name = "hn-analytical-platform"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "cryptography" },
+    { name = "duckdb" },
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "python-dotenv" },
@@ -283,6 +306,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.42.40" },
     { name = "cryptography", specifier = ">=46.0.4" },
+    { name = "duckdb", specifier = ">=1.3.0" },
     { name = "pandas", specifier = ">=3.0.0" },
     { name = "pyarrow", specifier = ">=23.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },


### PR DESCRIPTION
# Pull Request

Agregar capa analítica con queries de negocio y reportes en CSV

## Descripción
Implementa la última capa del pipeline ETL: una capa analítica que ejecuta consultas de negocio sobre los datos enriquecidos en `output/` usando DuckDB y persiste los resultados como reportes CSV en la nueva capa `reports/` del data lake.

Esta capa cierra el ciclo completo del pipeline (`ingestion -> processing -> transformation -> analytics`) y demuestra el valor de los datos transformados mediante KPIs concretos: top stories por velocity, engagement speed, stories long-tail, análisis de sentimiento por story y tendencias de topics.

**Contexto:** Cierra el proyecto de "última milla" de consumo analítico. El sistema estaba funcional en ingesta y transformación, pero faltaba una capa de reportes que demostrara insights sobre los datos enriquecidos.

## Alcance
### Añadido:
- **`src/analytics/hn_analytics.py`**: Clase `HNAnalytics` que lee Parquet desde S3 via DuckDB httpfs y ejecuta 5 queries de negocio:
  - `top_stories_by_score_velocity()`: Top stories ordenadas por velocidad de crecimiento
  - `engagement_speed()`: Clasificación de engagement (fast/medium/slow)
  - `long_tail_stories()`: Stories con actividad sostenida >48h
  - `sentiment_by_story()`: Análisis de sentimiento agregado por story
  - `topic_trends()`: Frecuencia y score promedio de topics dominantes

- **`src/analytics/main.py`**: Punto de entrada para ejecución (CLI). Patrón arquitectónico idéntico a `transformation/main.py`: inicializa boto3, `LayerStorageWriter`, ejecuta todas las queries, persiste CSV en `reports/`, sube logs a S3.

- **Infraestructura:**
  - `infrastructure/terraform/main.tf`: Nuevo prefijo `reports/` en el bucket S3 con particionamiento por `ingestion_date`
  - `infrastructure/orchestration/dags/dag.py`: Nueva task `analytics` encadenada después de `transformation`

- **Dependencias:**
  - `pyproject.toml`: Agrega `duckdb>=1.3.0`

### Modificado:
- **`src/utils/layer_storage_writer.py`**:
  - Agrega `"reports"` a `VALID_LAYERS`
  - Agrega `"csv"` a `VALID_FORMATS`
  - Nuevo método `_save_as_csv()` que serializa DataFrames a CSV con metadata S3
  - Actualiza firma de `save()` para aceptar los nuevos tipos

- **`src/utils/logger.py`**: Agrega `analytics_logger` para la nueva capa

- **`src/ingestion/hn_fetcher.py`**: Eliminación de import no utilizado (cleanup menor)

### Eliminado:
- Ninguno relevante (cleanup menor de imports)

## Tipo de cambio
- [ ] Corrección de error
- [x] Nueva funcionalidad
- [ ] Mejora de rendimiento o refactorización
- [ ] Documentación
- [x] Configuración/Herramientas

## Riesgos y mitigación
| Riesgo | Mitigación |
|--------|-----------|
| **UNNEST en DuckDB**: Query original de `topic_trends` fallaba con "Binder Error" | Se refactorizó con CTE intermedio: `string_split -> array`, `UNNEST` en CTE separado, `GROUP BY` en capa final. Probado localmente. |
| **Falta de datos en particiones**: Algunas queries pueden retornar vacías (ej. `long_tail_stories` si no hay datos >48h) | Código maneja DataFrames vacíos: logs de warning, stats de conteo, no bloquean el pipeline. |
| **Variables de entorno ausentes en S3**: Si `AWS_*` env vars son None | Mismo patrón que en `transformation/main.py` - error esxplícito en inicialización. |
| **Cambios en esquema de output/**: Si columnas esperadas desaparecen | DuckDB query fallará explícitamente; los logs capturan el error. Sin fallos silenciosos. |

## Validación
### Pruebas realizadas:
1. **Ejecución local**: Corrida exitosa de `python -m analytics.main 2026-02-21` con datos sintéticos en MinIO
   - Top stories: 1 fila generada (≤20 limit)
   - Engagement speed: 1 fila (3 categorías posibles, datos límitados)
   - Long tail stories: 0 filas (vacío, logged como warning, no bloqueante)
   - Sentiment by story: 1 fila
   - Topic trends: Falló inicialmente con `UNNEST`, ahora funciona con CTE

2. **Generación de reportes**: Todos los CSVs se escriben en S3 con estructura correcta:
   ```
   s3://hn-analytical-platform/reports/{report_name}/ingestion_date=2026-02-21/{report_name}_YYYYMMDD_HHMMSS.csv
   ```

3. **Idempotencia**: Múltiples ejecuciones con la misma fecha producen nuevos archivos con timestamp diferente (overwrite-safe por partición + timestamp)

4. **Logs**: Se suben a S3 (`logs/analytics/execution_date=...`) tras cada ejecución, incluso en caso de error

5. **DAG**: Sintaxis validada, encadenamiento correcto (`transformation >> analytics`)

## Checklist
- [x] Probado localmente o en entorno de prueba.
- [x] Documentación actualizada si aplica.
- [x] Sin advertencias ni errores nuevos en linters o tests.
- [x] Plan de rollback o cambios reversibles.
